### PR TITLE
Only support upstream supported Python versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies
@@ -22,9 +22,15 @@ jobs:
         pytest tests
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
+      with:
+        parallel: true
+        flag-name: Unit Test
+
   coveralls_finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: AndreMiras/coveralls-python-action@develop
+      with:
+        parallel-finished: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Configure Python ${{ matrix.python-version }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,12 @@
+name: Test with ruff
+
+on: ['pull_request', 'push']
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: chartboost/ruff-action@v1
+      with:
+        changed-files: 'true'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include .travis.yml
 include COPYING
 include NEWS.rst
 include README.rst
+include ruff.toml
 
 recursive-include doc *.rst
 include doc/conf.py

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Requirements
 ------------
 
 ``pyisbn`` does not depend on any modules that aren’t included in Python_’s
-standard library, and as such should run with Python 3.6 or newer [#]_.  If
+standard library, and as such should run with Python 3.8 or newer [#]_.  If
 ``pyisbn`` doesn’t work with the version of Python you have installed, open an
 issue_ and I’ll endeavour to fix it.
 

--- a/extra/requirements-dev.txt
+++ b/extra/requirements-dev.txt
@@ -1,12 +1,4 @@
 -r requirements-test.txt
-flake8>=3.9
-flake8-bugbear>=21.4
-flake8-chart>=0.1
-flake8-copyright>=0.2
-flake8-comprehensions>=3.5
-flake8-import-order>=0.18
-flake8-string-format>=0.3
+ruff>=0.4
 mutmut>=1.6
-pep8-naming>=0.11
-pep257>=0.7
 pytest-html>=2.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,38 @@
+target-version = "py36"
+
+exclude = [
+    ".git",
+    "build",
+    "dist",
+    "maybe",
+]
+
+
+[format]
+docstring-code-format = true
+
+# FIXME: This should be dropped, but it is the style in-place today
+quote-style = "single"
+
+[lint]
+extend-select = [
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "C90",  # mccabe
+  "CPY",  # flake8-copyright
+  "D",    # pydocstyle
+  "E",    # pycodestyle
+  "N",    # pep8-naming
+  "W",    # pycodestyle
+  "YTT",  # flake8-2020
+]
+
+[lint.flake8-copyright]
+min-file-size = 1
+notice-rgx = "Copyright © 20\\d{2}(-20\\d{2})? {2}"
+
+[lint.mccabe]
+max-complexity = 6
+
+[lint.pydocstyle]
+convention = "google"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py36"
+target-version = "py38"
 
 exclude = [
     ".git",

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,19 +16,6 @@ fail_under = 100
 precision = 2
 skip_covered = True
 
-[flake8]
-application-import-names =
-    pyisbn
-    tests
-copyright-check = True
-copyright-min-file-size = 1
-copyright-regexp = Copyright © 20\d{2}(-20\d{2})? {2}
-exclude = .git,build,maybe,pyisbn/_version.py
-ignore = P101
-import-order-style = pycharm
-max-complexity = 6
-select = C,E,F,I,W,B,B901,B902,B903,B950
-
 [metadata]
 name = pyisbn
 version = attr: pyisbn._version.dotted
@@ -75,12 +62,6 @@ runner = pytest -x
 [options]
 packages = pyisbn
 zip_safe = True
-
-[pycodestyle]
-select = E, W
-
-[pydocstyle]
-select = D203,D212,D404
 
 [tool:pytest]
 addopts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Other/Nonlisted Topic
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
This is long overdue, but will probably require some additional changes beyond just bumping the `setup.cfg` values.
